### PR TITLE
Added toggleAudio and toggleVideo

### DIFF
--- a/js/webrtc-v2.js
+++ b/js/webrtc-v2.js
@@ -460,6 +460,26 @@ const PHONE = window.PHONE = config => {
         if (!mystream) return;
         for (let track of mystream.getTracks()) track.stop();
     }
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+    // Toggle Mic
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+    function toggleAudio() {
+        if (!mystream) return;
+        for (let track of mystream.getAudioTracks() ){
+            track.enabled = !track.enabled ;
+        }
+    }
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+    // Toggle Camera
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+    function toggleVideo() {
+        if (!mystream) return;
+        for (let track of mystream.getVideoTracks() ){
+            track.enabled = !track.enabled ;
+        }
+    }
     
     // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     // Initiate Dialing Socket
@@ -598,6 +618,8 @@ const PHONE = window.PHONE = config => {
     PHONE.startcamera  = startcamera;
     PHONE.camera.start = startcamera;
     PHONE.camera.stop  = stopcamera;
+    PHONE.camera.toggleAudio  = toggleAudio;
+    PHONE.camera.toggleVideo  = toggleVideo;
     PHONE.camera.video = () => myvideo;
     PHONE.camera.ready = PHONE.camera;
 


### PR DESCRIPTION
This enables developers to change streams being sent mid-call by exposing functions as in:
`var phone = window.PHONE({...});
phone.camera.toggleAudio();
phone.camera.toggleVideo();`

.toggleVideo() might require some socket event to inform the other part it needs to hide the video or a black video will be shown.

These functions work only on initialized user devices. It does not take care of asking for new permissions or renegotiations. 